### PR TITLE
Fix link to segment in telemetry docs

### DIFF
--- a/pages/using/telemetry.mdx
+++ b/pages/using/telemetry.mdx
@@ -4,7 +4,7 @@ ReadySet collects telemetry data to help us diagnose issues and understand how u
 
 This telemetry data is anonymous by default. Users can opt into providing a persistent identifier, or disable telemetry completely.
 
-Telemetry is reported using the [Segment](segment.com) customer data platform.
+Telemetry is reported using the [Segment](https://segment.com) customer data platform.
 
 
 ## Disabling telemetry


### PR DESCRIPTION
segment.com was redirecting to
https://docs.readyset.io/using/segment.com rather than the intended https://segment.com